### PR TITLE
Fix duplicate messages being sent to app after the popup url changes

### DIFF
--- a/src/pop-up-window.ts
+++ b/src/pop-up-window.ts
@@ -231,6 +231,8 @@ export class PopUpWindow {
       func: routeMessagesToWindow,
       args: [messageTypePrefix]
     })
+
+    chrome.tabs.onUpdated.removeListener(this.scriptInjector)
   }
 
   private async getPopUpWindowId() : Promise<number | undefined> {


### PR DESCRIPTION
Related to #16 , these changes ensure that the content script won't be injected again to the same window, after the URL changes.