### PR TITLE
Fix PopUpWindow losing window reference

### DIFF
--- a/src/messaging/to-window.ts
+++ b/src/messaging/to-window.ts
@@ -11,16 +11,18 @@ export function routeMessagesToWindow(messageTypePrefix: string) {
   const mOrigin = '*'
 
   const messageRouterKey = `${messageTypePrefix}MessageRouter` as string
-  if (!(window as any)[messageRouterKey]) {
-    console.debug(`${logPrefix} Installing window message routing as window.${messageRouterKey}...`);
+  const installedMessageRouter = (window as any)[messageRouterKey]
+  if (installedMessageRouter) return
 
-    (window as any)[messageRouterKey] = (message: any, sender: MessageSender, sendResponse: any) => {
-      console.debug("Posting message to window:", message)
-      window.postMessage(message, mOrigin)  
-    }
-
-    chrome.runtime.onMessage.addListener((window as any)[messageRouterKey])
+  console.debug(`${logPrefix} Installing window message routing as window.${messageRouterKey}...`)
+  const listener = (message: any, sender: MessageSender, sendResponse: any) => {
+    console.debug("Posting message to window:", message)
+    window.postMessage(message, mOrigin)
   }
+
+  chrome.runtime.onMessage.addListener(listener);
+
+  (window as any)[messageRouterKey] = listener
 
   // Note that this script is injected into the app website loaded in the popup.
   // The first thing we'll do is to trigger the 'extension-token-requested'

--- a/src/pop-up-window.ts
+++ b/src/pop-up-window.ts
@@ -44,7 +44,6 @@ type WindowBounds = {
 }
 
 export class PopUpWindow {
-  id: number | undefined
   tabId: number | undefined
   url: string
   width: number | undefined
@@ -202,12 +201,11 @@ export class PopUpWindow {
     createData.focused = true
 
     let window = await chrome.windows.create(createData)
-    this.id = window.id
-    chrome.storage.local.set({popUpWindowId: this.id})
+    chrome.storage.local.set({popUpWindowId: window.id})
 
     this.tabId = (window.tabs || [])[0].id
     chrome.storage.local.set({popUpWindowTabId: this.tabId})
-  
+
     return window
   }
 

--- a/src/pop-up-window.ts
+++ b/src/pop-up-window.ts
@@ -70,7 +70,7 @@ export class PopUpWindow {
     this.left = args.left
     this.top = args.top
     this.windowResizeWaiters = []
-    
+
     this.actionMap = {}
     const tokenReq = `${messageTypePrefix}:extension-token-requested`
     this.actionMap[tokenReq] = this.handleTokenRequest.bind(this)

--- a/src/pop-up-window.ts
+++ b/src/pop-up-window.ts
@@ -54,6 +54,7 @@ export class PopUpWindow {
   uniqueId: number
   extensionId: string
   messageTypePrefix: string
+  logPrefix: string
 
   actionMap: { [name: string]: Function } // { [name: string]: Array<Function> }
   windowResizeWaiters: Array<Promise<Function>>
@@ -62,6 +63,7 @@ export class PopUpWindow {
     const { messageTypePrefix } = args
     this.extensionId = args.extensionId
     this.messageTypePrefix = messageTypePrefix
+    this.logPrefix = `[${this.messageTypePrefix} extension]`
     this.uniqueId = Math.random()
     this.url = args.url
     this.width = args.width
@@ -160,8 +162,7 @@ export class PopUpWindow {
 
   private handleTokenRequest(_message: any, _sender: any, sendResponse: any): void {
     let extensionToken = generateExtensionToken()
-    const logPrefix = `[${this.messageTypePrefix} extension]`
-    console.debug(`${logPrefix} Received token request. Responding with token "${extensionToken}"...`)
+    console.debug(`${this.logPrefix} Received token request. Responding with token "${extensionToken}"...`)
     sendResponse(extensionToken)
     return
   }


### PR DESCRIPTION
Whenever Chrome suspends the background worker, the reference to the PopUpWindow's window id was being lost, giving way to problems such as communication breaking, multiple popup windows, etc.

This PR solves this problem by:
- Removing the PopUpWindow id property
- Always read the window id from local storage, which was already being stored whenever the PopUpWindow gets created.