### PR TITLE
Allow websites to cleanup route responders

### DIFF
--- a/src/for-website.ts
+++ b/src/for-website.ts
@@ -40,6 +40,14 @@ export class Extension {
     }
   }
 
+  stopRoutingMessagesTo(subscribers?: { [name: string]: Function }) {
+    if (!subscribers) return this.actionMap = {}
+
+    for (const [messageType, _responder] of Object.entries(subscribers)) {
+      delete this.actionMap[messageType]
+    }
+  }
+
   sendMessage(message: any, options: chrome.runtime.MessageOptions, responseCallback?: ((response: any) => void) | undefined) {
     if (!extensionIsActive()) {
       this.warn("The extension is not active")

--- a/src/for-website.ts
+++ b/src/for-website.ts
@@ -22,8 +22,7 @@ export class Extension {
   }
 
   start() {
-    const logPrefix = `[${this.messageTypePrefix} website]`
-    console.debug(`${logPrefix} Waiting for connection requests from extension...`)
+    this.debug("Waiting for connection requests from extension...")
     window.addEventListener(
       "message",
       this.routeIncomingExtensionMessages.bind(this),
@@ -41,7 +40,7 @@ export class Extension {
 
   sendMessage(message: any, options: chrome.runtime.MessageOptions, responseCallback?: ((response: any) => void) | undefined) {
     if (!extensionIsActive()) {
-      console.warn("The extension is not active")
+      this.warn("The extension is not active")
       return
     }
 
@@ -75,15 +74,13 @@ export class Extension {
   // Requests a token from the extension:
   private handleConnectionStartRequest(message: any, _sender: chrome.runtime.MessageSender, _sendResponse: (response?: any) => void) {
     const { messageTypePrefix } = this
-    const logPrefix = `[${messageTypePrefix} website]`
-    
-    console.debug(`${logPrefix} Received connection request. Requesting token...`)
+    this.debug("Received connection request. Requesting token...")
+
     this.sendMessage(
       { type: `${messageTypePrefix}:extension-token-requested` },
       {},
       (token: string) => {
-        console.debug(`${logPrefix} Received token from extension: "${token}". Connection started.`)
-        window.sessionStorage.setItem(`${messageTypePrefix}:extension-token`, token)
+        this.debug(`Received token from extension: "${token}". Connection started.`)
 
         if (document) {
           const eventName = `${messageTypePrefix}:extension-connection-started`
@@ -91,5 +88,13 @@ export class Extension {
         }
       }
     )
+  }
+
+  private debug(message: any, ...extra: any[]) {
+    console.debug(`[${this.messageTypePrefix} website] ${message}`, ...extra)
+  }
+
+  private warn(message: any, ...extra: any[]) {
+    console.warn(`[${this.messageTypePrefix} website] ${message}`, ...extra)
   }
 }

--- a/src/for-website.ts
+++ b/src/for-website.ts
@@ -9,12 +9,14 @@ function extensionIsActive() {
 
 export class Extension {
   extensionId: string
+  tokenStorageKey: string
   messageTypePrefix: string
   actionMap: { [name: string]: Function } // { [name: string]: Array<Function> }
 
   constructor(args: any) {
     this.extensionId = args.extensionId
     this.messageTypePrefix = args.messageTypePrefix
+    this.tokenStorageKey = `${this.messageTypePrefix}:extension-token`
 
     const connStartReq = `${this.messageTypePrefix}:extension-connection-start-requested`
     this.actionMap = {}
@@ -81,6 +83,7 @@ export class Extension {
       {},
       (token: string) => {
         this.debug(`Received token from extension: "${token}". Connection started.`)
+        window.sessionStorage.setItem(this.tokenStorageKey, token)
 
         if (document) {
           const eventName = `${messageTypePrefix}:extension-connection-started`


### PR DESCRIPTION
Given that websites loaded as a popup window might need to de-subscribe event listeners - specially those handling messages coming from the extension - this PR adds a method that allows website code to do that.