### PR TITLE
Make public the popup window id and window getter methods

### DIFF
--- a/src/pop-up-window.ts
+++ b/src/pop-up-window.ts
@@ -326,7 +326,7 @@ export class PopUpWindow {
     return
   }
 
-  private async getPopUpWindowId() : Promise<number | undefined> {
+  public async getPopUpWindowId() : Promise<number | undefined> {
     const popUpWindowIsOpen = await this.getWindowIsOpen()
     if (!popUpWindowIsOpen) return
     const popUpWindowId = await readFromLocalStorage('popUpWindowId') as number
@@ -342,8 +342,7 @@ export class PopUpWindow {
     return popUpWindowId
   }
 
-  private async getPopUpWindow() : Promise<Window | undefined> {
-
+  public async getPopUpWindow() : Promise<Window | undefined> {
     let popUpWindowId = await this.getPopUpWindowId()
     if (!popUpWindowId) {
       console.warn(


### PR DESCRIPTION
Somehow we now need to get a hold of the extension window's ID and window object.

these changes makes public the `PopUpWindow.getPopUpWindow`and `PopUpWindow.getPopUpWindowId` methods.